### PR TITLE
Fix warning: DeprecatedWarning: share is deprecated as of 2.3.0 and h…

### DIFF
--- a/update_ags_online_fs.py
+++ b/update_ags_online_fs.py
@@ -4,7 +4,7 @@ import os, sys
 from arcgis.gis import GIS
 import logging
 import datetime
-#from arcgis.gis._impl._content_manager import SharingLevel
+from arcgis.gis._impl._content_manager import SharingLevel
 
 
 # load settings from settings_ags_online.py
@@ -70,20 +70,19 @@ def update_feature_services(project_path, sd_fs_name):
       LOGGER.debug("Overwriting existing feature service...")
       fs = sdItem.publish(overwrite=True)
 
-      if shrOrg or shrEveryone or shrGroups:
-        LOGGER.debug("Setting sharing options...")
-        fs.share(org=shrOrg, everyone=shrEveryone, groups=shrGroups)
-      #sharing_mgr = fs.sharing
-      #if shrOrg:
-        #sharing_mgr.sharing_level = SharingLevel.ORG
-      #if shrEveryone:
-        #sharing_mgr.sharing_level = SharingLevel.EVERYONE
-      #if shrGroups:
-        #for groupID in shrGroups:
-          #group = gis.groups.get(groupID)
-          #item_grp_sharing_mgr = sharing_mgr.groups
-          #item_grp_sharing_mgr.add(group=group)
-
+      #if shrOrg or shrEveryone or shrGroups:
+      #  LOGGER.debug("Setting sharing options...")
+      #  fs.share(org=shrOrg, everyone=shrEveryone, groups=shrGroups)
+      sharing_mgr = fs.sharing
+      if shrOrg:
+        sharing_mgr.sharing_level = SharingLevel.ORG
+      if shrEveryone:
+        sharing_mgr.sharing_level = SharingLevel.EVERYONE
+      if shrGroups:
+        for groupID in shrGroups:
+          group = gis.groups.get(groupID)
+          item_grp_sharing_mgr = sharing_mgr.groups
+          item_grp_sharing_mgr.add(group=group)
 
       LOGGER.info("Finished updating: {} – ID: {}".format(fs.title, fs.id))
     else:


### PR DESCRIPTION
…as be removed in 3.0.0. Use `Item.sharing` instead.