### PR TITLE
issue #8: urllib3 >= 1.24, < 2.6.0 is now subject to high severity se…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 https://github.com/jkeifer/arcpy-extensions/tarball/0.0.1
 suds-jurko==0.6
-requests==2.29.0
-urllib3==1.26.8
-arcgis==1.8.4


### PR DESCRIPTION
…curity alerts. I pulled out the changes I made in August 2023 and the script still appears to run with updated/current version of ArcGIS Pro